### PR TITLE
deps: updates wazero to 1.0.0-pre.4

### DIFF
--- a/01-wasi-simple-function/go.mod
+++ b/01-wasi-simple-function/go.mod
@@ -2,4 +2,4 @@ module wasi-simple-function
 
 go 1.18
 
-require github.com/tetratelabs/wazero v1.0.0-pre.2
+require github.com/tetratelabs/wazero v1.0.0-pre.4

--- a/01-wasi-simple-function/go.sum
+++ b/01-wasi-simple-function/go.sum
@@ -1,2 +1,2 @@
-github.com/tetratelabs/wazero v1.0.0-pre.2 h1:sHYi8DKUL7s7c4sKz6lw0pNqky5EogYK0Iq4pSIsDog=
-github.com/tetratelabs/wazero v1.0.0-pre.2/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
+github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
+github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=

--- a/02-wasi-print-string/go.mod
+++ b/02-wasi-print-string/go.mod
@@ -2,4 +2,4 @@ module wasi-print-string
 
 go 1.18
 
-require github.com/tetratelabs/wazero v1.0.0-pre.2
+require github.com/tetratelabs/wazero v1.0.0-pre.4

--- a/02-wasi-print-string/go.sum
+++ b/02-wasi-print-string/go.sum
@@ -1,2 +1,2 @@
-github.com/tetratelabs/wazero v1.0.0-pre.2 h1:sHYi8DKUL7s7c4sKz6lw0pNqky5EogYK0Iq4pSIsDog=
-github.com/tetratelabs/wazero v1.0.0-pre.2/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
+github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
+github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=

--- a/02-wasi-print-string/main.go
+++ b/02-wasi-print-string/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 
 	"github.com/tetratelabs/wazero"
-  "github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 )
 
@@ -22,7 +22,7 @@ func main() {
 
 	// host functions
 	_, err := wasmRuntime.NewHostModuleBuilder("env").
-  ExportFunction("log", logString).
+		NewFunctionBuilder().WithFunc(logString).Export("log").
 		Instantiate(ctx, wasmRuntime)
 	if err != nil {
 		log.Panicln(err)

--- a/03-wasi-string-param/go.mod
+++ b/03-wasi-string-param/go.mod
@@ -2,4 +2,4 @@ module wasi-string-param
 
 go 1.18
 
-require github.com/tetratelabs/wazero v1.0.0-pre.2
+require github.com/tetratelabs/wazero v1.0.0-pre.4

--- a/03-wasi-string-param/go.sum
+++ b/03-wasi-string-param/go.sum
@@ -1,2 +1,2 @@
-github.com/tetratelabs/wazero v1.0.0-pre.2 h1:sHYi8DKUL7s7c4sKz6lw0pNqky5EogYK0Iq4pSIsDog=
-github.com/tetratelabs/wazero v1.0.0-pre.2/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
+github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
+github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=

--- a/03-wasi-string-param/main.go
+++ b/03-wasi-string-param/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 
 	"github.com/tetratelabs/wazero"
-  "github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 )
 
@@ -22,7 +22,7 @@ func main() {
 
 	// host functions
 	_, err := wasmRuntime.NewHostModuleBuilder("env").
-  ExportFunction("log", logString).
+		NewFunctionBuilder().WithFunc(logString).Export("log").
 		Instantiate(ctx, wasmRuntime)
 	if err != nil {
 		log.Panicln(err)
@@ -59,11 +59,11 @@ func main() {
 
 	fmt.Println("result:", result[0])
 
-  funcPrintHello := mod.ExportedFunction("print_hello")
+	funcPrintHello := mod.ExportedFunction("print_hello")
 	allocate := mod.ExportedFunction("allocate")
 	deallocate := mod.ExportedFunction("deallocate")
 
-  name := "Bob Morane"
+	name := "Bob Morane"
 	nameSize := uint64(len(name))
 
 	// Instead of an arbitrary memory offset, use Rust's allocator. Notice
@@ -89,7 +89,6 @@ func main() {
 	if err != nil {
 		log.Panicln(err)
 	}
-
 
 }
 

--- a/04-wasi-string-param-return-string/go.mod
+++ b/04-wasi-string-param-return-string/go.mod
@@ -2,4 +2,4 @@ module wasi-string-return
 
 go 1.18
 
-require github.com/tetratelabs/wazero v1.0.0-pre.2
+require github.com/tetratelabs/wazero v1.0.0-pre.4

--- a/04-wasi-string-param-return-string/go.sum
+++ b/04-wasi-string-param-return-string/go.sum
@@ -1,2 +1,2 @@
-github.com/tetratelabs/wazero v1.0.0-pre.2 h1:sHYi8DKUL7s7c4sKz6lw0pNqky5EogYK0Iq4pSIsDog=
-github.com/tetratelabs/wazero v1.0.0-pre.2/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
+github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
+github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=

--- a/04-wasi-string-param-return-string/main.go
+++ b/04-wasi-string-param-return-string/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 
 	"github.com/tetratelabs/wazero"
-  "github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 )
 
@@ -22,7 +22,7 @@ func main() {
 
 	// host functions
 	_, err := wasmRuntime.NewHostModuleBuilder("env").
-  ExportFunction("log", logString).
+		NewFunctionBuilder().WithFunc(logString).Export("log").
 		Instantiate(ctx, wasmRuntime)
 	if err != nil {
 		log.Panicln(err)
@@ -59,11 +59,11 @@ func main() {
 
 	fmt.Println("result:", result[0])
 
-  funcPrintHello := mod.ExportedFunction("print_hello")
+	funcPrintHello := mod.ExportedFunction("print_hello")
 	allocate := mod.ExportedFunction("allocate")
 	deallocate := mod.ExportedFunction("deallocate")
 
-  name := "Bob Morane"
+	name := "Bob Morane"
 	nameSize := uint64(len(name))
 
 	// Instead of an arbitrary memory offset, use Rust's allocator. Notice
@@ -90,8 +90,7 @@ func main() {
 		log.Panicln(err)
 	}
 
-
-  funcReturnHello := mod.ExportedFunction("return_hello")
+	funcReturnHello := mod.ExportedFunction("return_hello")
 	ptrSize, err := funcReturnHello.Call(ctx, namePtr, nameSize)
 	if err != nil {
 		log.Panicln(err)
@@ -105,11 +104,10 @@ func main() {
 	// The pointer is a linear memory offset, which is where we write the name.
 	if bytes, ok := mod.Memory().Read(ctx, helloPtr, helloSize); !ok {
 		log.Panicf("Memory.Read(%d, %d) out of range of memory size %d",
-    helloPtr, helloSize, mod.Memory().Size(ctx))
+			helloPtr, helloSize, mod.Memory().Size(ctx))
 	} else {
 		fmt.Println("go >>", string(bytes))
 	}
-
 
 }
 

--- a/05-use-host-function-helpers/go.mod
+++ b/05-use-host-function-helpers/go.mod
@@ -2,4 +2,4 @@ module use-host-function-helpers
 
 go 1.18
 
-require github.com/tetratelabs/wazero v1.0.0-pre.2
+require github.com/tetratelabs/wazero v1.0.0-pre.4

--- a/05-use-host-function-helpers/go.sum
+++ b/05-use-host-function-helpers/go.sum
@@ -1,2 +1,2 @@
-github.com/tetratelabs/wazero v1.0.0-pre.2 h1:sHYi8DKUL7s7c4sKz6lw0pNqky5EogYK0Iq4pSIsDog=
-github.com/tetratelabs/wazero v1.0.0-pre.2/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
+github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
+github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=

--- a/05-use-host-function-helpers/main.go
+++ b/05-use-host-function-helpers/main.go
@@ -1,117 +1,115 @@
 package main
 
 import (
-	"context"
-	"fmt"
-	"log"
-	"os"
+  "context"
+  "fmt"
+  "log"
+  "os"
 
-	"github.com/tetratelabs/wazero"
+  "github.com/tetratelabs/wazero"
   "github.com/tetratelabs/wazero/api"
-	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
+  "github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 )
 
 func main() {
-	// Choose the context to use for function calls.
-	ctx := context.Background()
+  // Choose the context to use for function calls.
+  ctx := context.Background()
 
-	// Create a new WebAssembly Runtime.
-	wasmRuntime := wazero.NewRuntime(ctx)
+  // Create a new WebAssembly Runtime.
+  wasmRuntime := wazero.NewRuntime(ctx)
 
-	defer wasmRuntime.Close(ctx) // This closes everything this Runtime created.
+  defer wasmRuntime.Close(ctx) // This closes everything this Runtime created.
 
-	// host functions
-	_, err := wasmRuntime.NewHostModuleBuilder("env").
-  ExportFunction("log", logString).
-		Instantiate(ctx, wasmRuntime)
-	if err != nil {
-		log.Panicln(err)
-	}
+  // host functions
+  _, err := wasmRuntime.NewHostModuleBuilder("env").
+    NewFunctionBuilder().WithFunc(logString).Export("log").
+    Instantiate(ctx, wasmRuntime)
+  if err != nil {
+    log.Panicln(err)
+  }
 
-	_, err = wasi_snapshot_preview1.Instantiate(ctx, wasmRuntime)
-	if err != nil {
-		log.Panicln(err)
-	}
+  _, err = wasi_snapshot_preview1.Instantiate(ctx, wasmRuntime)
+  if err != nil {
+    log.Panicln(err)
+  }
 
-	// Load then Instantiate a WebAssembly module
-	wasmPath1 := "./functions/hey/target/wasm32-wasi/debug/hey.wasm"
-	//wasmPath2 := "./functions/hello/hello.wasm"
-	helloWasm, err := os.ReadFile(wasmPath1)
+  // Load then Instantiate a WebAssembly module
+  wasmPath1 := "./functions/hey/target/wasm32-wasi/debug/hey.wasm"
+  //wasmPath2 := "./functions/hello/hello.wasm"
+  helloWasm, err := os.ReadFile(wasmPath1)
 
-	if err != nil {
-		log.Panicln(err)
-	}
+  if err != nil {
+    log.Panicln(err)
+  }
 
-	mod, err := wasmRuntime.InstantiateModuleFromBinary(ctx, helloWasm)
-	if err != nil {
-		log.Panicln(err)
-	}
+  mod, err := wasmRuntime.InstantiateModuleFromBinary(ctx, helloWasm)
+  if err != nil {
+    log.Panicln(err)
+  }
 
-	// Get references to WebAssembly function: "add"
-	addWasmModuleFunction := mod.ExportedFunction("add")
+  // Get references to WebAssembly function: "add"
+  addWasmModuleFunction := mod.ExportedFunction("add")
 
-	// Now, we can call "add", which reads the data we wrote to memory!
-	// result []uint64
-	result, err := addWasmModuleFunction.Call(ctx, 20, 22)
-	if err != nil {
-		log.Panicln(err)
-	}
+  // Now, we can call "add", which reads the data we wrote to memory!
+  // result []uint64
+  result, err := addWasmModuleFunction.Call(ctx, 20, 22)
+  if err != nil {
+    log.Panicln(err)
+  }
 
-	fmt.Println("result:", result[0])
+  fmt.Println("result:", result[0])
 
   funcPrintHello := mod.ExportedFunction("print_hello")
-	allocate := mod.ExportedFunction("allocate")
-	deallocate := mod.ExportedFunction("deallocate")
+  allocate := mod.ExportedFunction("allocate")
+  deallocate := mod.ExportedFunction("deallocate")
 
   name := "Bob Morane"
-	nameSize := uint64(len(name))
+  nameSize := uint64(len(name))
 
-	// Instead of an arbitrary memory offset, use Rust's allocator. Notice
-	// there is nothing string-specific in this allocation function. The same
-	// function could be used to pass binary serialized data to Wasm.
-	results, err := allocate.Call(ctx, nameSize)
-	if err != nil {
-		log.Panicln(err)
-	}
-	namePtr := results[0]
-	// This pointer was allocated by Rust, but owned by Go, So, we have to
-	// deallocate it when finished
-	defer deallocate.Call(ctx, namePtr, nameSize)
+  // Instead of an arbitrary memory offset, use Rust's allocator. Notice
+  // there is nothing string-specific in this allocation function. The same
+  // function could be used to pass binary serialized data to Wasm.
+  results, err := allocate.Call(ctx, nameSize)
+  if err != nil {
+    log.Panicln(err)
+  }
+  namePtr := results[0]
+  // This pointer was allocated by Rust, but owned by Go, So, we have to
+  // deallocate it when finished
+  defer deallocate.Call(ctx, namePtr, nameSize)
 
-	// The pointer is a linear memory offset, which is where we write the name.
-	if !mod.Memory().Write(ctx, uint32(namePtr), []byte(name)) {
-		log.Panicf("Memory.Write(%d, %d) out of range of memory size %d",
-			namePtr, nameSize, mod.Memory().Size(ctx))
-	}
+  // The pointer is a linear memory offset, which is where we write the name.
+  if !mod.Memory().Write(ctx, uint32(namePtr), []byte(name)) {
+    log.Panicf("Memory.Write(%d, %d) out of range of memory size %d",
+      namePtr, nameSize, mod.Memory().Size(ctx))
+  }
 
   nickName := "Bob Morane"
-	nickNameSize := uint64(len(nickName))
-	resultsBis, err := allocate.Call(ctx, nickNameSize)
-	if err != nil {
-		log.Panicln(err)
-	}
+  nickNameSize := uint64(len(nickName))
+  resultsBis, err := allocate.Call(ctx, nickNameSize)
+  if err != nil {
+    log.Panicln(err)
+  }
   nickNamePtr := resultsBis[0]
-	defer deallocate.Call(ctx, nickNamePtr, nickNameSize)
+  defer deallocate.Call(ctx, nickNamePtr, nickNameSize)
 
-	if !mod.Memory().Write(ctx, uint32(nickNamePtr), []byte(nickName)) {
-		log.Panicf("Memory.Write(%d, %d) out of range of memory size %d",
-    nickNamePtr, nickNameSize, mod.Memory().Size(ctx))
-	}
+  if !mod.Memory().Write(ctx, uint32(nickNamePtr), []byte(nickName)) {
+    log.Panicf("Memory.Write(%d, %d) out of range of memory size %d",
+      nickNamePtr, nickNameSize, mod.Memory().Size(ctx))
+  }
 
-
-	// Now, we can call "greet", which reads the string we wrote to memory!
-	_, err = funcPrintHello.Call(ctx, nickNamePtr, nickNameSize)
-	if err != nil {
-		log.Panicln(err)
-	}
-
+  // Now, we can call "greet", which reads the string we wrote to memory!
+  _, err = funcPrintHello.Call(ctx, nickNamePtr, nickNameSize)
+  if err != nil {
+    log.Panicln(err)
+  }
 
 }
 
 func logString(ctx context.Context, m api.Module, offset, byteCount uint32) {
-	buf, ok := m.Memory().Read(ctx, offset, byteCount)
-	if !ok {
-		log.Panicf("Memory.Read(%d, %d) out of range", offset, byteCount)
-	}
-	fmt.Println(string(buf))
+  buf, ok := m.Memory().Read(ctx, offset, byteCount)
+  if !ok {
+    log.Panicf("Memory.Read(%d, %d) out of range", offset, byteCount)
+  }
+  fmt.Println(string(buf))
 }


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.4](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.4).

Notably, v1.0.0-pre.4:
* improves module initialization speed
* supports listeners in the compiler engine
* supports WASI `fd_pread`, `fd_readdir` and `path_filestat_get`
* breaks GoModuleFunc API