### PR TITLE
deps: updates wazero to 1.0.1

### DIFF
--- a/01-wasi-simple-function/go.mod
+++ b/01-wasi-simple-function/go.mod
@@ -2,4 +2,4 @@ module wasi-simple-function
 
 go 1.18
 
-require github.com/tetratelabs/wazero v1.0.0-pre.4
+require github.com/tetratelabs/wazero v1.0.1

--- a/01-wasi-simple-function/go.sum
+++ b/01-wasi-simple-function/go.sum
@@ -1,2 +1,2 @@
-github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
-github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/tetratelabs/wazero v1.0.1 h1:xyWBoGyMjYekG3mEQ/W7xm9E05S89kJ/at696d/9yuc=
+github.com/tetratelabs/wazero v1.0.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=

--- a/01-wasi-simple-function/main.go
+++ b/01-wasi-simple-function/main.go
@@ -36,7 +36,7 @@ func main() {
 		log.Panicln(err)
 	}
 
-	mod, err := r.InstantiateModuleFromBinary(ctx, helloWasm)
+	mod, err := r.Instantiate(ctx, helloWasm)
 	if err != nil {
 		log.Panicln(err)
 	}

--- a/02-wasi-print-string/go.mod
+++ b/02-wasi-print-string/go.mod
@@ -2,4 +2,4 @@ module wasi-print-string
 
 go 1.18
 
-require github.com/tetratelabs/wazero v1.0.0-pre.4
+require github.com/tetratelabs/wazero v1.0.1

--- a/02-wasi-print-string/go.sum
+++ b/02-wasi-print-string/go.sum
@@ -1,2 +1,2 @@
-github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
-github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/tetratelabs/wazero v1.0.1 h1:xyWBoGyMjYekG3mEQ/W7xm9E05S89kJ/at696d/9yuc=
+github.com/tetratelabs/wazero v1.0.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=

--- a/02-wasi-print-string/main.go
+++ b/02-wasi-print-string/main.go
@@ -23,7 +23,7 @@ func main() {
 	// host functions
 	_, err := wasmRuntime.NewHostModuleBuilder("env").
 		NewFunctionBuilder().WithFunc(logString).Export("log").
-		Instantiate(ctx, wasmRuntime)
+		Instantiate(ctx)
 	if err != nil {
 		log.Panicln(err)
 	}
@@ -42,7 +42,7 @@ func main() {
 		log.Panicln(err)
 	}
 
-	mod, err := wasmRuntime.InstantiateModuleFromBinary(ctx, helloWasm)
+	mod, err := wasmRuntime.Instantiate(ctx, helloWasm)
 	if err != nil {
 		log.Panicln(err)
 	}
@@ -62,7 +62,7 @@ func main() {
 }
 
 func logString(ctx context.Context, m api.Module, offset, byteCount uint32) {
-	buf, ok := m.Memory().Read(ctx, offset, byteCount)
+	buf, ok := m.Memory().Read(offset, byteCount)
 	if !ok {
 		log.Panicf("Memory.Read(%d, %d) out of range", offset, byteCount)
 	}

--- a/03-wasi-string-param/go.mod
+++ b/03-wasi-string-param/go.mod
@@ -2,4 +2,4 @@ module wasi-string-param
 
 go 1.18
 
-require github.com/tetratelabs/wazero v1.0.0-pre.4
+require github.com/tetratelabs/wazero v1.0.1

--- a/03-wasi-string-param/go.sum
+++ b/03-wasi-string-param/go.sum
@@ -1,2 +1,2 @@
-github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
-github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/tetratelabs/wazero v1.0.1 h1:xyWBoGyMjYekG3mEQ/W7xm9E05S89kJ/at696d/9yuc=
+github.com/tetratelabs/wazero v1.0.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=

--- a/03-wasi-string-param/main.go
+++ b/03-wasi-string-param/main.go
@@ -23,7 +23,7 @@ func main() {
 	// host functions
 	_, err := wasmRuntime.NewHostModuleBuilder("env").
 		NewFunctionBuilder().WithFunc(logString).Export("log").
-		Instantiate(ctx, wasmRuntime)
+		Instantiate(ctx)
 	if err != nil {
 		log.Panicln(err)
 	}
@@ -42,7 +42,7 @@ func main() {
 		log.Panicln(err)
 	}
 
-	mod, err := wasmRuntime.InstantiateModuleFromBinary(ctx, helloWasm)
+	mod, err := wasmRuntime.Instantiate(ctx, helloWasm)
 	if err != nil {
 		log.Panicln(err)
 	}
@@ -79,9 +79,9 @@ func main() {
 	defer deallocate.Call(ctx, namePtr, nameSize)
 
 	// The pointer is a linear memory offset, which is where we write the name.
-	if !mod.Memory().Write(ctx, uint32(namePtr), []byte(name)) {
+	if !mod.Memory().Write(uint32(namePtr), []byte(name)) {
 		log.Panicf("Memory.Write(%d, %d) out of range of memory size %d",
-			namePtr, nameSize, mod.Memory().Size(ctx))
+			namePtr, nameSize, mod.Memory().Size())
 	}
 
 	// Now, we can call "greet", which reads the string we wrote to memory!
@@ -93,7 +93,7 @@ func main() {
 }
 
 func logString(ctx context.Context, m api.Module, offset, byteCount uint32) {
-	buf, ok := m.Memory().Read(ctx, offset, byteCount)
+	buf, ok := m.Memory().Read(offset, byteCount)
 	if !ok {
 		log.Panicf("Memory.Read(%d, %d) out of range", offset, byteCount)
 	}

--- a/04-wasi-string-param-return-string/go.mod
+++ b/04-wasi-string-param-return-string/go.mod
@@ -2,4 +2,4 @@ module wasi-string-return
 
 go 1.18
 
-require github.com/tetratelabs/wazero v1.0.0-pre.4
+require github.com/tetratelabs/wazero v1.0.1

--- a/04-wasi-string-param-return-string/go.sum
+++ b/04-wasi-string-param-return-string/go.sum
@@ -1,2 +1,2 @@
-github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
-github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/tetratelabs/wazero v1.0.1 h1:xyWBoGyMjYekG3mEQ/W7xm9E05S89kJ/at696d/9yuc=
+github.com/tetratelabs/wazero v1.0.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=

--- a/04-wasi-string-param-return-string/main.go
+++ b/04-wasi-string-param-return-string/main.go
@@ -23,7 +23,7 @@ func main() {
 	// host functions
 	_, err := wasmRuntime.NewHostModuleBuilder("env").
 		NewFunctionBuilder().WithFunc(logString).Export("log").
-		Instantiate(ctx, wasmRuntime)
+		Instantiate(ctx)
 	if err != nil {
 		log.Panicln(err)
 	}
@@ -42,7 +42,7 @@ func main() {
 		log.Panicln(err)
 	}
 
-	mod, err := wasmRuntime.InstantiateModuleFromBinary(ctx, helloWasm)
+	mod, err := wasmRuntime.Instantiate(ctx, helloWasm)
 	if err != nil {
 		log.Panicln(err)
 	}
@@ -79,9 +79,9 @@ func main() {
 	defer deallocate.Call(ctx, namePtr, nameSize)
 
 	// The pointer is a linear memory offset, which is where we write the name.
-	if !mod.Memory().Write(ctx, uint32(namePtr), []byte(name)) {
+	if !mod.Memory().Write(uint32(namePtr), []byte(name)) {
 		log.Panicf("Memory.Write(%d, %d) out of range of memory size %d",
-			namePtr, nameSize, mod.Memory().Size(ctx))
+			namePtr, nameSize, mod.Memory().Size())
 	}
 
 	// Now, we can call "greet", which reads the string we wrote to memory!
@@ -102,9 +102,9 @@ func main() {
 	defer deallocate.Call(ctx, uint64(helloPtr), uint64(helloSize))
 
 	// The pointer is a linear memory offset, which is where we write the name.
-	if bytes, ok := mod.Memory().Read(ctx, helloPtr, helloSize); !ok {
+	if bytes, ok := mod.Memory().Read(helloPtr, helloSize); !ok {
 		log.Panicf("Memory.Read(%d, %d) out of range of memory size %d",
-			helloPtr, helloSize, mod.Memory().Size(ctx))
+			helloPtr, helloSize, mod.Memory().Size())
 	} else {
 		fmt.Println("go >>", string(bytes))
 	}
@@ -112,7 +112,7 @@ func main() {
 }
 
 func logString(ctx context.Context, m api.Module, offset, byteCount uint32) {
-	buf, ok := m.Memory().Read(ctx, offset, byteCount)
+	buf, ok := m.Memory().Read(offset, byteCount)
 	if !ok {
 		log.Panicf("Memory.Read(%d, %d) out of range", offset, byteCount)
 	}

--- a/05-use-host-function-helpers/go.mod
+++ b/05-use-host-function-helpers/go.mod
@@ -2,4 +2,4 @@ module use-host-function-helpers
 
 go 1.18
 
-require github.com/tetratelabs/wazero v1.0.0-pre.4
+require github.com/tetratelabs/wazero v1.0.1

--- a/05-use-host-function-helpers/go.sum
+++ b/05-use-host-function-helpers/go.sum
@@ -1,2 +1,2 @@
-github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
-github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/tetratelabs/wazero v1.0.1 h1:xyWBoGyMjYekG3mEQ/W7xm9E05S89kJ/at696d/9yuc=
+github.com/tetratelabs/wazero v1.0.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=

--- a/05-use-host-function-helpers/main.go
+++ b/05-use-host-function-helpers/main.go
@@ -1,115 +1,115 @@
 package main
 
 import (
-  "context"
-  "fmt"
-  "log"
-  "os"
+	"context"
+	"fmt"
+	"log"
+	"os"
 
-  "github.com/tetratelabs/wazero"
-  "github.com/tetratelabs/wazero/api"
-  "github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
+	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 )
 
 func main() {
-  // Choose the context to use for function calls.
-  ctx := context.Background()
+	// Choose the context to use for function calls.
+	ctx := context.Background()
 
-  // Create a new WebAssembly Runtime.
-  wasmRuntime := wazero.NewRuntime(ctx)
+	// Create a new WebAssembly Runtime.
+	wasmRuntime := wazero.NewRuntime(ctx)
 
-  defer wasmRuntime.Close(ctx) // This closes everything this Runtime created.
+	defer wasmRuntime.Close(ctx) // This closes everything this Runtime created.
 
-  // host functions
-  _, err := wasmRuntime.NewHostModuleBuilder("env").
-    NewFunctionBuilder().WithFunc(logString).Export("log").
-    Instantiate(ctx, wasmRuntime)
-  if err != nil {
-    log.Panicln(err)
-  }
+	// host functions
+	_, err := wasmRuntime.NewHostModuleBuilder("env").
+		NewFunctionBuilder().WithFunc(logString).Export("log").
+		Instantiate(ctx)
+	if err != nil {
+		log.Panicln(err)
+	}
 
-  _, err = wasi_snapshot_preview1.Instantiate(ctx, wasmRuntime)
-  if err != nil {
-    log.Panicln(err)
-  }
+	_, err = wasi_snapshot_preview1.Instantiate(ctx, wasmRuntime)
+	if err != nil {
+		log.Panicln(err)
+	}
 
-  // Load then Instantiate a WebAssembly module
-  wasmPath1 := "./functions/hey/target/wasm32-wasi/debug/hey.wasm"
-  //wasmPath2 := "./functions/hello/hello.wasm"
-  helloWasm, err := os.ReadFile(wasmPath1)
+	// Load then Instantiate a WebAssembly module
+	wasmPath1 := "./functions/hey/target/wasm32-wasi/debug/hey.wasm"
+	//wasmPath2 := "./functions/hello/hello.wasm"
+	helloWasm, err := os.ReadFile(wasmPath1)
 
-  if err != nil {
-    log.Panicln(err)
-  }
+	if err != nil {
+		log.Panicln(err)
+	}
 
-  mod, err := wasmRuntime.InstantiateModuleFromBinary(ctx, helloWasm)
-  if err != nil {
-    log.Panicln(err)
-  }
+	mod, err := wasmRuntime.Instantiate(ctx, helloWasm)
+	if err != nil {
+		log.Panicln(err)
+	}
 
-  // Get references to WebAssembly function: "add"
-  addWasmModuleFunction := mod.ExportedFunction("add")
+	// Get references to WebAssembly function: "add"
+	addWasmModuleFunction := mod.ExportedFunction("add")
 
-  // Now, we can call "add", which reads the data we wrote to memory!
-  // result []uint64
-  result, err := addWasmModuleFunction.Call(ctx, 20, 22)
-  if err != nil {
-    log.Panicln(err)
-  }
+	// Now, we can call "add", which reads the data we wrote to memory!
+	// result []uint64
+	result, err := addWasmModuleFunction.Call(ctx, 20, 22)
+	if err != nil {
+		log.Panicln(err)
+	}
 
-  fmt.Println("result:", result[0])
+	fmt.Println("result:", result[0])
 
-  funcPrintHello := mod.ExportedFunction("print_hello")
-  allocate := mod.ExportedFunction("allocate")
-  deallocate := mod.ExportedFunction("deallocate")
+	funcPrintHello := mod.ExportedFunction("print_hello")
+	allocate := mod.ExportedFunction("allocate")
+	deallocate := mod.ExportedFunction("deallocate")
 
-  name := "Bob Morane"
-  nameSize := uint64(len(name))
+	name := "Bob Morane"
+	nameSize := uint64(len(name))
 
-  // Instead of an arbitrary memory offset, use Rust's allocator. Notice
-  // there is nothing string-specific in this allocation function. The same
-  // function could be used to pass binary serialized data to Wasm.
-  results, err := allocate.Call(ctx, nameSize)
-  if err != nil {
-    log.Panicln(err)
-  }
-  namePtr := results[0]
-  // This pointer was allocated by Rust, but owned by Go, So, we have to
-  // deallocate it when finished
-  defer deallocate.Call(ctx, namePtr, nameSize)
+	// Instead of an arbitrary memory offset, use Rust's allocator. Notice
+	// there is nothing string-specific in this allocation function. The same
+	// function could be used to pass binary serialized data to Wasm.
+	results, err := allocate.Call(ctx, nameSize)
+	if err != nil {
+		log.Panicln(err)
+	}
+	namePtr := results[0]
+	// This pointer was allocated by Rust, but owned by Go, So, we have to
+	// deallocate it when finished
+	defer deallocate.Call(ctx, namePtr, nameSize)
 
-  // The pointer is a linear memory offset, which is where we write the name.
-  if !mod.Memory().Write(ctx, uint32(namePtr), []byte(name)) {
-    log.Panicf("Memory.Write(%d, %d) out of range of memory size %d",
-      namePtr, nameSize, mod.Memory().Size(ctx))
-  }
+	// The pointer is a linear memory offset, which is where we write the name.
+	if !mod.Memory().Write(uint32(namePtr), []byte(name)) {
+		log.Panicf("Memory.Write(%d, %d) out of range of memory size %d",
+			namePtr, nameSize, mod.Memory().Size())
+	}
 
-  nickName := "Bob Morane"
-  nickNameSize := uint64(len(nickName))
-  resultsBis, err := allocate.Call(ctx, nickNameSize)
-  if err != nil {
-    log.Panicln(err)
-  }
-  nickNamePtr := resultsBis[0]
-  defer deallocate.Call(ctx, nickNamePtr, nickNameSize)
+	nickName := "Bob Morane"
+	nickNameSize := uint64(len(nickName))
+	resultsBis, err := allocate.Call(ctx, nickNameSize)
+	if err != nil {
+		log.Panicln(err)
+	}
+	nickNamePtr := resultsBis[0]
+	defer deallocate.Call(ctx, nickNamePtr, nickNameSize)
 
-  if !mod.Memory().Write(ctx, uint32(nickNamePtr), []byte(nickName)) {
-    log.Panicf("Memory.Write(%d, %d) out of range of memory size %d",
-      nickNamePtr, nickNameSize, mod.Memory().Size(ctx))
-  }
+	if !mod.Memory().Write(uint32(nickNamePtr), []byte(nickName)) {
+		log.Panicf("Memory.Write(%d, %d) out of range of memory size %d",
+			nickNamePtr, nickNameSize, mod.Memory().Size())
+	}
 
-  // Now, we can call "greet", which reads the string we wrote to memory!
-  _, err = funcPrintHello.Call(ctx, nickNamePtr, nickNameSize)
-  if err != nil {
-    log.Panicln(err)
-  }
+	// Now, we can call "greet", which reads the string we wrote to memory!
+	_, err = funcPrintHello.Call(ctx, nickNamePtr, nickNameSize)
+	if err != nil {
+		log.Panicln(err)
+	}
 
 }
 
 func logString(ctx context.Context, m api.Module, offset, byteCount uint32) {
-  buf, ok := m.Memory().Read(ctx, offset, byteCount)
-  if !ok {
-    log.Panicf("Memory.Read(%d, %d) out of range", offset, byteCount)
-  }
-  fmt.Println(string(buf))
+	buf, ok := m.Memory().Read(offset, byteCount)
+	if !ok {
+		log.Panicf("Memory.Read(%d, %d) out of range", offset, byteCount)
+	}
+	fmt.Println(string(buf))
 }


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.1](https://github.com/tetratelabs/wazero/releases/tag/v1.0.1).

On behalf of everyone in the community, I want to thank you for trying wazero before we became stable. We will not raise unsolicited pull requests anymore. That said, if any update gives you problems, please feel free to contact [us](https://wazero.io/community/) on slack or via a GitHub issue.

This PR also includes changes for [wazero](https://wazero.io/) [1.0.0-rc.2][0], [1.0.0-pre.9][1],
[wazero](https://wazero.io/) [1.0.0-pre.8][2]. Notably:

* Requires at least Go 1.8
* Renames `Runtime.InstantiateModuleFromBinary` to `Runtime.Instantiate`
* This release also integrates Go context to limit execution time.
  More details on the [Release Notes][1]
* Changes the `Instantiate` signature, which no longer requires
  an explicit `Runtime` instance.
* Changes the `Memory` `Read`/`Write` signatures, which no longer
  take a `Context`
* Full support to the WASI test suite and other third-party integration tests
* A number of optimizations to reduce compilation overhead


Finally, if you would like to share your work, feel free to update our [users page](https://github.com/tetratelabs/wazero/blob/main/site/content/community/users.md)!

[0]: https://github.com/tetratelabs/wazero/releases/tag/1.0.0-rc.2
[1]: https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.9
[2]: https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.8

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>
